### PR TITLE
Fix bug where sessionId gets stuck in the "waiting" state

### DIFF
--- a/presence_client.js
+++ b/presence_client.js
@@ -13,7 +13,7 @@ Meteor.Presence = {
   // overwrite the correct thing
   // XXX: should probably use a session var for this so it survives HCR
   // but it causes some complexities with loops below, so I'll skip for now.
-  sessionId: null,
+  sessionId: '',
   
   // call this function to manually update the presence _right_ now
   // use this if your state() function contains non-reactive elements that have 
@@ -60,7 +60,8 @@ Meteor.autorun(function() {
     Meteor.Presence.sessionId, 
     Meteor.Presence.state(), function(err, sessionId) {
       if (err) {
-        console.log(err);
+        console.log('setPresence returned error:', err);
+        Meteor.Presence.sessionId = '';
         return;
       }
       


### PR DESCRIPTION
The first time you send your presence to the server by calling setPresence(), it will pass a null sessionId. This sessionId fails the check on the server side and returns a Match Error to the client. The client ignores this error and leaves sessionId in the "waiting" state. From that point, it will never again try to send a presence to the server because the sessionId is stuck at "waiting".

This bug was introduced in 712449006273f319e97304810b113cd28950c2c6 with the audit-argument-checks compliance.
