### PR TITLE
Flexible intervals & bugfixes

### DIFF
--- a/presence_client.js
+++ b/presence_client.js
@@ -1,28 +1,87 @@
-PRESENCE_INTERVAL = 1000;
-
 // Set `Meteor.Presence.state` to keep track of what users are doing.
 //
 // This function will be called a) reactively, b) every 1 second
 //
+var computation = null;
+var interval = null;
 Meteor.Presence = {
   // The presnce will contained in, which will be reset to null
   // when they close the browser tab or log off
   state: function() { return 'online'; },
-  
+
   // we get told about the sessionId by the server, track it here so we
   // overwrite the correct thing
   // XXX: should probably use a session var for this so it survives HCR
   // but it causes some complexities with loops below, so I'll skip for now.
   sessionId: '',
-  
+
   // call this function to manually update the presence _right_ now
-  // use this if your state() function contains non-reactive elements that have 
+  // use this if your state() function contains non-reactive elements that have
   // changed
   update: function() {
     Session.set('last-presence-set-at', new Date());
-  }
-}
+  },
 
+  INTERVAL: 1000,
+
+  start: function(){
+    Meteor.Presence.stop();
+    // update presences every interval
+    interval = Meteor.setInterval(function() {
+      Meteor.Presence.update();
+    }, Meteor.Presence.INTERVAL);
+    // this is code that actually does it.
+    computation = Meteor.autorun(refreshPresence);
+  },
+
+  stop: function(){
+    if (computation !== null) {
+      computation.stop();
+      computation = null;
+    }
+    if (interval !== null){
+      Meteor.clearInterval(interval);
+      interval = null;
+    }
+  }
+};
+
+var abortedWhileWaiting = false;
+function refreshPresence() {
+  // read the state, so context is invalidated every time it changes
+  var state = Meteor.Presence.state();
+  // read this, so the context is invalidated every time the interval changes
+  Session.get('last-presence-set-at');
+
+  // also read userId so context is invalidated as soon as login state changes
+  Meteor.userId();
+
+  // check if waiting for Meteor.call to return
+  if (Meteor.Presence.sessionId === 'waiting'){
+    abortedWhileWaiting = true;
+    return;
+  } else {
+    // we can clear the abort flag, as this will be successful
+    abortedWhileWaiting = false;
+  }
+
+  Meteor.call('setPresence',
+    Meteor.Presence.sessionId,
+    state, function(err, sessionId) {
+      if (err) {
+        console.log('setPresence returned error:', err);
+        Meteor.Presence.sessionId = '';
+        return;
+      }
+      Meteor.Presence.sessionId = sessionId;
+      if (abortedWhileWaiting){
+        refreshPresence()
+      }
+    }
+  );
+  // set the sessionId to 'waiting' if it's empty
+  Meteor.Presence.sessionId = Meteor.Presence.sessionId || 'waiting';
+}
 
 // try to maintain sessionId across hot-code-reload
 if (Meteor._reload) {
@@ -37,37 +96,7 @@ if (Meteor._reload) {
     }
   })();
 }
-
-// update presences every interval
-Meteor.setInterval(function() {
-  Meteor.Presence.update();
-}, PRESENCE_INTERVAL);
-
-// this is code that actually does it.
-Meteor.autorun(function() {
-  // read this, so the context is invalidated every time the interval changes
-  Session.get('last-presence-set-at');
-  
-  // also read userId so context is invalidated as soon as login state changes
-  Meteor.userId();
-  
-  // if we have made our first call, but it hasn't yet returned, 
-  // don't make another
-  if (Meteor.Presence.sessionId === 'waiting')
-    return;
-  
-  Meteor.call('setPresence', 
-    Meteor.Presence.sessionId, 
-    Meteor.Presence.state(), function(err, sessionId) {
-      if (err) {
-        console.log('setPresence returned error:', err);
-        Meteor.Presence.sessionId = '';
-        return;
-      }
-      
-      // console.log(Meteor.Presence.sessionId, sessionId);
-      Meteor.Presence.sessionId = sessionId;
-    }
-  );
-  Meteor.Presence.sessionId = Meteor.Presence.sessionId || 'waiting';
+// wait until startup so that client code can set their own INTERVAL & state function
+Meteor.startup(function(){
+  Meteor.Presence.start();
 });

--- a/presence_client.js
+++ b/presence_client.js
@@ -4,6 +4,10 @@
 //
 var computation = null;
 var interval = null;
+var INTERVAL = 1000;
+if (typeof Meteor.settings !== "undefined" && typeof Meteor.settings.public !== "undefined"){
+  INTERVAL = Meteor.settings.public.presenceInterval || INTERVAL;
+}
 Meteor.Presence = {
   // The presnce will contained in, which will be reset to null
   // when they close the browser tab or log off
@@ -22,14 +26,12 @@ Meteor.Presence = {
     Session.set('last-presence-set-at', new Date());
   },
 
-  INTERVAL: 1000,
-
   start: function(){
     Meteor.Presence.stop();
     // update presences every interval
     interval = Meteor.setInterval(function() {
       Meteor.Presence.update();
-    }, Meteor.Presence.INTERVAL);
+    }, INTERVAL);
     // this is code that actually does it.
     computation = Meteor.autorun(refreshPresence);
   },
@@ -96,7 +98,7 @@ if (Meteor._reload) {
     }
   })();
 }
-// wait until startup so that client code can set their own INTERVAL & state function
+// wait until startup so that client code can set their own state function
 Meteor.startup(function(){
   Meteor.Presence.start();
 });

--- a/presence_server.js
+++ b/presence_server.js
@@ -1,5 +1,3 @@
-PRESENCE_TIMEOUT_MS = 10000;
-PRESENCE_INTERVAL = 1000;
 
 // a method to indicate that the user is still online
 Meteor.methods({
@@ -7,25 +5,25 @@ Meteor.methods({
     // console.log(sessionId, state);
     check(sessionId, String);
     check(state, Match.Any);
-    
+
     // we use the sessionId to tell if this is a new record or not
     var props = {
         state: state,
         lastSeen: new Date()
     };
-    
+
     var userId = _.isUndefined(Meteor.userId) ? null : Meteor.userId();
-    
+
     if (sessionId && Meteor.presences.findOne(sessionId)) {
       var update = {$set: props};
-      
+
       // need to unset userId if it's not defined as they may have just logged out
       if (userId) {
         update.$set.userId = userId;
       } else {
         update.$unset = {userId: true};
       }
-      
+
       Meteor.presences.update({_id: sessionId}, update);
       return sessionId;
     } else {
@@ -35,7 +33,23 @@ Meteor.methods({
   }
 });
 
-Meteor.setInterval(function() {
-  var since = new Date(new Date().getTime() - PRESENCE_TIMEOUT_MS);
-  Meteor.presences.remove({lastSeen: {$lt: since}});
-}, PRESENCE_INTERVAL);
+var interval = null;
+Meteor.Presence = {
+  INTERVAL: 1000,
+  TIMEOUT: 10000,
+  start: function(){
+    if (interval !== null){
+      Meteor.clearInterval(interval)
+    }
+    interval = Meteor.setInterval(function() {
+      var since = new Date(new Date().getTime() - Meteor.Presence.TIMEOUT);
+      Meteor.presences.remove({lastSeen: {$lt: since}});
+    }, Meteor.Presence.INTERVAL);
+  }
+};
+
+// wait until startup so that client code can set their own INTERVAL / TIMEOUT
+Meteor.startup(function(){
+  Meteor.Presence.start();
+});
+

--- a/presence_server.js
+++ b/presence_server.js
@@ -34,6 +34,14 @@ Meteor.methods({
 });
 
 var interval = null;
+var INTERVAL = 1000;
+var TIMEOUT = 10000;
+if (typeof Meteor.settings !== "undefined"){
+  TIMEOUT = Meteor.settings.presenceTimeout || TIMEOUT;
+  if (typeof Meteor.settings.public !== "undefined"){
+    INTERVAL = Meteor.settings.public.presenceInterval || INTERVAL;
+  }
+}
 Meteor.Presence = {
   INTERVAL: 1000,
   TIMEOUT: 10000,
@@ -42,9 +50,9 @@ Meteor.Presence = {
       Meteor.clearInterval(interval)
     }
     interval = Meteor.setInterval(function() {
-      var since = new Date(new Date().getTime() - Meteor.Presence.TIMEOUT);
+      var since = new Date(new Date().getTime() - TIMEOUT);
       Meteor.presences.remove({lastSeen: {$lt: since}});
-    }, Meteor.Presence.INTERVAL);
+    }, INTERVAL);
   }
 };
 


### PR DESCRIPTION
This pull request fixes a few issues that I experienced implementing this in an application.

```
1. Presence starts running before "client" code can change the "state" function - meaning on every load their state gets set to "online".
2. The interval isn't configurable
3. State changes get skipped if the client sessionId is set to "waiting" - this has a large effect when you increase the client interval.
```

The only questionable issue with these changes - is whether it is bad for the client to set their own ID - but as there's no other trust mechanism (eg, server can't enforce which ID a client wants to send) then it probably doesn't matter.
